### PR TITLE
errors and blanks in lecture slide 1

### DIFF
--- a/Lecture 1- Time Series/lecture1_time_series.tex
+++ b/Lecture 1- Time Series/lecture1_time_series.tex
@@ -181,7 +181,7 @@ ggplot(gdp, aes(date, price)) + geom_line() +
 \begin{frame}{Notation}
 We observe a sample $\{y_1,y_2,\ldots,y_{t-1},y_{t},y_{t+1}\}$.
 \begin{itemize}
-\item We call $y_{y-1}$ the \alert{first lag} of $y_t$.
+\item We call $y_{t-1}$ the \alert{first lag} of $y_t$.
 \item We call $\Delta y_{t} = y_{t} - y_{t-1}$ the \alert{first difference}
 \item We might also want $\Delta \ln y_{t} = \ln y_{t} - \ln y_{t-1}$
 \item We can approximate percentage change as  $100 \cdot \Delta \ln y_{t}$
@@ -372,7 +372,7 @@ y_t &= \beta_0 + \sum_{k=1}^p \beta_k y_{t-k} + \varepsilon_{t}
 \end{align*}
 Or an $ARMA(p,q)$ which adds moving average terms:
 \begin{align*}
-y_t &= \beta_0 + \sum_{k=1}^p \beta_k y_{t-k} + \sum_{k=1}^p \theta_k \varepsilon_{t-k} 
+y_t &= \beta_0 + \sum_{k=1}^p \beta_k y_{t-k} + \sum_{k=1}^q \theta_k \varepsilon_{t-k} 
 \end{align*}
 \begin{itemize}
 \item An important question is \alert{selecting the order of the lag} $p$


### PR DESCRIPTION
Corrected an error on page 8, line 184, where it should be y_{t-1}.

Page 15 and 16 are identical at lines 285 to 302, perhaps not intentional?

Page 17, line 305 shows no contents, perhaps the code does not work properly.

Corrected an error on page 21, line 375, where the super-script of the last sum term should be q instead of p.

Page 24, lines starting at 408, does not show any contents. 

Page 27, lines starting at 442, does not show any contents.

Page 28, lines starting at 473 only shows one line of texts but not the regression outputs. 

Page 29, lines starting at 489, is similar to the issue on page 28.

Page 35, lines starting at 543, does not show any contents.

Page 45, 46, do not show any contents, starting at line 680 to 709.